### PR TITLE
Fixing dates check

### DIFF
--- a/import_octopress_posts.py
+++ b/import_octopress_posts.py
@@ -89,7 +89,7 @@ def octo_parse(octo_post):
             else:
                 d = meta['date']
                 # strings sometimes result from the yaml when it has no seconds
-                if not isinstance(d, datetime.datetime):
+                if not isinstance(d, datetime.date):
                     d = dateutil.parser.parse(d)
                 meta['date'] = d.strftime("%Y/%m/%d %H:%M")
             meta['slug'] = slug


### PR DESCRIPTION
I only use date, not hours in my posts, and the script was failing.

As far as:

``` python
>>> import datetime
>>> isinstance(datetime.datetime.today(), datetime.date)
True
>>> isinstance(datetime.datetime.today(), datetime.datetime)
True
>>> isinstance(datetime.date.today(), datetime.date)
True
>>> isinstance(datetime.date.today(), datetime.datetime)
False
```

I've changed the check to `datetime.date` instead of `datetime.datetime`
